### PR TITLE
Bypass paypal login screen

### DIFF
--- a/Moolah/Moolah/Moolah.csproj
+++ b/Moolah/Moolah/Moolah.csproj
@@ -38,7 +38,7 @@
       <HintPath>..\..\lib\GCheckout\GCheckout.dll</HintPath>
     </Reference>
     <Reference Include="NLog">
-      <HintPath>..\packages\NLog.2.0.0.2000\lib\net40\NLog.dll</HintPath>
+      <HintPath>..\..\..\tynpay\packages\NLog.2.0.0.2000\lib\net40\NLog.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
@@ -90,6 +90,7 @@
     <Compile Include="PaymentResponses.cs" />
     <Compile Include="PaymentStatus.cs" />
     <Compile Include="PayPal\CurrencyCodeType.cs" />
+    <Compile Include="PayPal\LandingPage.cs" />
     <Compile Include="PayPal\LocaleCodes.cs" />
     <Compile Include="PayPal\OrderDetails.cs" />
     <Compile Include="PayPal\PayPalConfiguration.cs" />
@@ -102,6 +103,7 @@
     <Compile Include="PayPal\PayPalRequestBuilder.cs" />
     <Compile Include="PayPal\PayPalResponseParser.cs" />
     <Compile Include="PayPal\PayPalAck.cs" />
+    <Compile Include="PayPal\SolutionType.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Culture.cs" />
     <Compile Include="TimeProvider.cs" />

--- a/Moolah/Moolah/Moolah.csproj
+++ b/Moolah/Moolah/Moolah.csproj
@@ -92,6 +92,7 @@
     <Compile Include="PayPal\CurrencyCodeType.cs" />
     <Compile Include="PayPal\LandingPage.cs" />
     <Compile Include="PayPal\LocaleCodes.cs" />
+    <Compile Include="PayPal\ShippingAddressType.cs" />
     <Compile Include="PayPal\OrderDetails.cs" />
     <Compile Include="PayPal\PayPalConfiguration.cs" />
     <Compile Include="PayPal\PayPalDecimalExtension.cs" />

--- a/Moolah/Moolah/PayPal/LandingPage.cs
+++ b/Moolah/Moolah/PayPal/LandingPage.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Moolah.PayPal
+{
+    public enum LandingPage
+    {
+        /// <summary>
+        /// Set the Paypal landing page to Billing
+        /// </summary>
+        Billing
+    }
+}

--- a/Moolah/Moolah/PayPal/OrderDetails.cs
+++ b/Moolah/Moolah/PayPal/OrderDetails.cs
@@ -61,6 +61,18 @@ namespace Moolah.PayPal
         /// </summary>
         public bool? EnableCustomerMarketingEmailOptIn { get; set; }
         /// <summary>
+        /// Sets whether Paypal is the only method of payment.
+        /// If this is set to Sole, and LandingPage is set to Billing, then you don't
+        /// have to login to Paypal to make a payment with Express Checkout - you can pay directly with your credit card
+        /// </summary>
+        public SolutionType? SolutionType { get; set; }
+        /// <summary>
+        /// What page at Paypal to start at when using Express Checkout.
+        /// If this is set to Billing, and SolutionType is set to Sole, then you don't need
+        /// to login to Paypal to make a payment with Express Checkout - you can pay directly with your credit card
+        /// </summary>
+        public LandingPage? LandingPage { get; set; }
+        /// <summary>
         /// A free-form field for your own use. The value you specify is available only if the transaction includes a purchase.
         /// This field is ignored if you set up a billing agreement for a recurring payment that is not immediately charged.
         /// Character length and limitations: 256 single-byte alphanumeric characters

--- a/Moolah/Moolah/PayPal/OrderDetails.cs
+++ b/Moolah/Moolah/PayPal/OrderDetails.cs
@@ -73,6 +73,9 @@ namespace Moolah.PayPal
         /// </summary>
         public LandingPage? LandingPage { get; set; }
 
+        public ShippingAddressType? NoShipping { get; set; }
+        public bool? ReqConfirmShipping { get; set; }
+
         public string ShipToName { get; set; }
         public string ShipToStreet { get; set; }
         public string ShipToCity { get; set; }

--- a/Moolah/Moolah/PayPal/OrderDetails.cs
+++ b/Moolah/Moolah/PayPal/OrderDetails.cs
@@ -72,6 +72,16 @@ namespace Moolah.PayPal
         /// to login to Paypal to make a payment with Express Checkout - you can pay directly with your credit card
         /// </summary>
         public LandingPage? LandingPage { get; set; }
+
+        public string ShipToName { get; set; }
+        public string ShipToStreet { get; set; }
+        public string ShipToCity { get; set; }
+        public string ShipToState { get; set; }
+        public string ShipToZip { get; set; }
+        public string ShipToCountryCode { get; set; }
+        public string Email { get; set; }
+        public string ShipToPhoneNum { get; set; }
+
         /// <summary>
         /// A free-form field for your own use. The value you specify is available only if the transaction includes a purchase.
         /// This field is ignored if you set up a billing agreement for a recurring payment that is not immediately charged.

--- a/Moolah/Moolah/PayPal/PayPalRequestBuilder.cs
+++ b/Moolah/Moolah/PayPal/PayPalRequestBuilder.cs
@@ -59,6 +59,8 @@ namespace Moolah.PayPal
             // SetExpressCheckout specific
             addOptionalValueToRequest("ALLOWNOTE", orderDetails.AllowNote, request);
             addOptionalValueToRequest("BUYEREMAILOPTINENABLE", orderDetails.EnableCustomerMarketingEmailOptIn, request);
+            addOptionalValueToRequest("SOLUTIONTYPE", orderDetails.SolutionType.ToString(), request);
+            addOptionalValueToRequest("LANDINGPAGE", orderDetails.LandingPage.ToString(), request);
 
             return request;
         }

--- a/Moolah/Moolah/PayPal/PayPalRequestBuilder.cs
+++ b/Moolah/Moolah/PayPal/PayPalRequestBuilder.cs
@@ -73,6 +73,28 @@ namespace Moolah.PayPal
             addOptionalValueToRequest("PAYMENTREQUEST_0_CUSTOM", orderDetails.CustomField, request);
             addOptionalValueToRequest("PAYMENTREQUEST_0_DESC", orderDetails.OrderDescription, request);
 
+            // Add payer information
+            addOptionalValueToRequest("PAYMENTREQUEST_0_SHIPTONAME", orderDetails.ShipToName, request);
+            addOptionalValueToRequest("PAYMENTREQUEST_0_SHIPTOSTREET", orderDetails.ShipToStreet, request);
+            addOptionalValueToRequest("PAYMENTREQUEST_0_SHIPTOCITY", orderDetails.ShipToCity, request);
+            addOptionalValueToRequest("PAYMENTREQUEST_0_SHIPTOSTATE", orderDetails.ShipToState, request);
+            addOptionalValueToRequest("PAYMENTREQUEST_0_SHIPTOCOUNTRYCODE", orderDetails.ShipToCountryCode, request);
+            addOptionalValueToRequest("PAYMENTREQUEST_0_SHIPTOZIP", orderDetails.ShipToZip, request);
+            // This one isn't documented in all places
+            addOptionalValueToRequest("PAYMENTREQUEST_0_EMAIL", orderDetails.Email, request);
+            addOptionalValueToRequest("PAYMENTREQUEST_0_SHIPTOPHONENUM", orderDetails.ShipToPhoneNum, request);
+            
+            // These are supposed to be deprecated in favor of the above, but my sandbox was ignoring the above
+            addOptionalValueToRequest("SHIPTONAME", orderDetails.ShipToName, request);
+            addOptionalValueToRequest("SHIPTOSTREET", orderDetails.ShipToStreet, request);
+            addOptionalValueToRequest("SHIPTOCITY", orderDetails.ShipToCity, request);
+            addOptionalValueToRequest("SHIPTOSTATE", orderDetails.ShipToState, request);
+            addOptionalValueToRequest("SHIPTOCOUNTRYCODE", orderDetails.ShipToCountryCode, request);
+            addOptionalValueToRequest("SHIPTOZIP", orderDetails.ShipToZip, request);
+            // This one isn't documented
+            addOptionalValueToRequest("EMAIL", orderDetails.Email, request);
+            addOptionalValueToRequest("SHIPTOPHONENUM", orderDetails.ShipToPhoneNum, request);
+
             var lineNumber = 0;
             var itemTotal = 0m;
             if (orderDetails.Items != null)

--- a/Moolah/Moolah/PayPal/PayPalRequestBuilder.cs
+++ b/Moolah/Moolah/PayPal/PayPalRequestBuilder.cs
@@ -65,6 +65,13 @@ namespace Moolah.PayPal
             return request;
         }
 
+        void addOptionalValueToRequest(string field, string value, NameValueCollection request, string defaultVal)
+        {
+            addOptionalValueToRequest(field, value, request);
+            if (request[field] == null)
+                request[field] = defaultVal;
+        }
+
         void addOrderDetailsValues(OrderDetails orderDetails, NameValueCollection request)
         {
             addOptionalValueToRequest("PAYMENTREQUEST_0_TAXAMT", orderDetails.TaxTotal, request);
@@ -73,7 +80,10 @@ namespace Moolah.PayPal
             addOptionalValueToRequest("PAYMENTREQUEST_0_CUSTOM", orderDetails.CustomField, request);
             addOptionalValueToRequest("PAYMENTREQUEST_0_DESC", orderDetails.OrderDescription, request);
 
+            addOptionalValueToRequest("REQCONFIRMSHIPPING", orderDetails.ReqConfirmShipping, request);
+
             // Add payer information
+            addOptionalValueToRequest("NOSHIPPING", (int?)orderDetails.NoShipping, request);
             addOptionalValueToRequest("PAYMENTREQUEST_0_SHIPTONAME", orderDetails.ShipToName, request);
             addOptionalValueToRequest("PAYMENTREQUEST_0_SHIPTOSTREET", orderDetails.ShipToStreet, request);
             addOptionalValueToRequest("PAYMENTREQUEST_0_SHIPTOCITY", orderDetails.ShipToCity, request);
@@ -85,6 +95,7 @@ namespace Moolah.PayPal
             addOptionalValueToRequest("PAYMENTREQUEST_0_SHIPTOPHONENUM", orderDetails.ShipToPhoneNum, request);
             
             // These are supposed to be deprecated in favor of the above, but my sandbox was ignoring the above
+            addOptionalValueToRequest("NO_SHIPPING", (int?)orderDetails.NoShipping, request);
             addOptionalValueToRequest("SHIPTONAME", orderDetails.ShipToName, request);
             addOptionalValueToRequest("SHIPTOSTREET", orderDetails.ShipToStreet, request);
             addOptionalValueToRequest("SHIPTOCITY", orderDetails.ShipToCity, request);

--- a/Moolah/Moolah/PayPal/ShippingAddressType.cs
+++ b/Moolah/Moolah/PayPal/ShippingAddressType.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Moolah.PayPal
+{
+    public enum ShippingAddressType
+    {
+        Optional = 0,
+        None = 1,
+        Require = 2
+    }
+}

--- a/Moolah/Moolah/PayPal/SolutionType.cs
+++ b/Moolah/Moolah/PayPal/SolutionType.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Moolah.PayPal
+{
+    public enum SolutionType
+    {
+        /// <summary>
+        /// Is paypal the standalone payment gateway?
+        /// </summary>
+        Sole
+    }
+}

--- a/Moolah/Moolah/packages.config
+++ b/Moolah/Moolah/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NLog" version="2.0.0.2000" />
+  <package id="NLog" version="2.0.0.2000" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
By setting the SolutionType and LandingPage, you can bypass the paypal login page and go directly to the credit-card entry screen of paypal when using Express Checkout.
