### PR TITLE
Added support for optional fields on the PayPal SetExpressCheckout call

### DIFF
--- a/Moolah/Moolah/PayPal/PayPalExpressCheckout.cs
+++ b/Moolah/Moolah/PayPal/PayPalExpressCheckout.cs
@@ -64,6 +64,18 @@ namespace Moolah.PayPal
             return setExpressCheckoutRequestFor(request);
         }
 
+        public PayPalExpressCheckoutToken SetExpressCheckout(OrderDetails orderDetails, string cancelUrl, string confirmationUrl, NameValueCollection optionalFields)
+        {
+            if(orderDetails == null) throw new ArgumentNullException("orderDetails");
+            if(string.IsNullOrWhiteSpace(cancelUrl)) throw new ArgumentNullException("cancelUrl");
+            if(string.IsNullOrWhiteSpace(confirmationUrl)) throw new ArgumentNullException("confirmationUrl");
+
+            _logger.Log("SetExpressCheckout.Request", orderDetails);
+
+            var request = _requestBuilder.SetExpressCheckout(orderDetails, cancelUrl, confirmationUrl, optionalFields);
+            return setExpressCheckoutRequestFor(request);
+        }
+
         PayPalExpressCheckoutToken setExpressCheckoutRequestFor(NameValueCollection request)
         {
             var response = sendToPayPal(request);

--- a/Moolah/Moolah/PayPal/PayPalRequestBuilder.cs
+++ b/Moolah/Moolah/PayPal/PayPalRequestBuilder.cs
@@ -9,6 +9,7 @@ namespace Moolah.PayPal
     {
         NameValueCollection SetExpressCheckout(decimal amount, CurrencyCodeType currencyCodeType, string cancelUrl, string confirmationUrl);
         NameValueCollection SetExpressCheckout(OrderDetails orderDetails, string cancelUrl, string confirmationUrl);
+        NameValueCollection SetExpressCheckout(OrderDetails orderDetails, string cancelUrl, string confirmationUrl, NameValueCollection optionalFields);
         NameValueCollection GetExpressCheckoutDetails(string payPalToken);
         NameValueCollection DoExpressCheckoutPayment(decimal amount, CurrencyCodeType currencyCodeType, string payPalToken, string payPalPayerId);
         NameValueCollection DoExpressCheckoutPayment(OrderDetails orderDetails, string payPalToken, string payPalPayerId);
@@ -60,6 +61,20 @@ namespace Moolah.PayPal
             // SetExpressCheckout specific
             addOptionalValueToRequest("ALLOWNOTE", orderDetails.AllowNote, request);
             addOptionalValueToRequest("BUYEREMAILOPTINENABLE", orderDetails.EnableCustomerMarketingEmailOptIn, request);
+
+            return request;
+        }
+
+        public NameValueCollection SetExpressCheckout(OrderDetails orderDetails, string cancelUrl, string confirmationUrl, NameValueCollection optionalFields)
+        {
+            var request = SetExpressCheckout(orderDetails, cancelUrl, confirmationUrl);
+
+            foreach(string key in optionalFields)
+            {
+                //Make sure we're not overwriting a field that's already been set
+                if(request[key] == null)
+                    addOptionalValueToRequest(key, optionalFields[key], request);
+            }
 
             return request;
         }


### PR DESCRIPTION
I added an overload to SetExpressCheckout in order to have the ability to supply some of the optional fields PayPal provides to customize the customer's checkout experience. I have multiple sites that feed in to the same PayPal account, so this allows me to swap out header images and brand names.
