### PR TITLE
PayPal API...

### DIFF
--- a/Moolah/Moolah.Specs/PayPal/PayPalRequestBuilderRefundSpec.cs
+++ b/Moolah/Moolah.Specs/PayPal/PayPalRequestBuilderRefundSpec.cs
@@ -37,7 +37,7 @@ namespace Moolah.Specs.PayPal
         It should_specify_transaction_id = () =>
             Request["TRANSACTIONID"].ShouldEqual(TransactionId);
 
-        It should_specify_amount = () =>
+        It should_specify_amount_rounded_to_two_decimal_places = () =>
             Request["AMT"].ShouldEqual("100.10");
 
         It should_specify_currency_code = () =>
@@ -50,7 +50,7 @@ namespace Moolah.Specs.PayPal
             Request = SUT.RefundPartialTransaction(TransactionId, Amount, CurrencyCode, Description);
 
         const string TransactionId = "QWE123";
-        const decimal Amount = 100.10m;
+        const decimal Amount = 100.1000m;
         const CurrencyCodeType CurrencyCode = CurrencyCodeType.PLN;
         const string Description = "Refund!";
     }

--- a/Moolah/Moolah/PayPal/PayPalRequestBuilder.cs
+++ b/Moolah/Moolah/PayPal/PayPalRequestBuilder.cs
@@ -206,7 +206,7 @@ namespace Moolah.PayPal
             request["METHOD"] = "RefundTransaction";
             request["TRANSACTIONID"] = transactionId;
             request["REFUNDTYPE"] = "Partial";
-            request["AMT"] = amount.ToString();
+            request["AMT"] = amount.ToString("0.00");
             request["CURRENCYCODE"] = currencyCodeType.ToString();
             request["NOTE"] = description;
             return request;


### PR DESCRIPTION
When we were refunding 3.99 for delivery it was converted to a string as a "3.9900" and PayPal was returning very meaningful error that stated that amount cannot be negative...
